### PR TITLE
[FEAT#32] 선석 변경 pr 승인 로직 구현

### DIFF
--- a/src/main/java/com/portmate/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/portmate/domain/schedule/controller/ScheduleController.java
@@ -45,7 +45,7 @@ public class ScheduleController {
         scheduleService.uploadExcel(file, request);
     }
 
-    @GetMapping("/{scheduleId}/assign")
+    @PostMapping("/{scheduleId}/assign")
     public ResponseEntity<ApiResponse<List<AssignedShipResponse>>> assign(@PathVariable String scheduleId) {
         return ResponseEntity.ok(ApiResponse.onSuccess(berthAssignmentService.assignByScheduleId(scheduleId)));
     }

--- a/src/main/java/com/portmate/domain/schedule/controller/ScheduleVersionController.java
+++ b/src/main/java/com/portmate/domain/schedule/controller/ScheduleVersionController.java
@@ -56,4 +56,41 @@ public class ScheduleVersionController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
+    
+    @PostMapping("/{versionId}/approve")
+    public ResponseEntity<ApiResponse<ReviewActionResponse>> approveVersion(
+            @PathVariable String versionId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody ReviewActionRequest request
+    ) {
+        ReviewActionResponse response = scheduleVersionService.approveVersion(
+                versionId, 
+                userDetails.getEmail(),
+                request
+        );
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+    
+    @PostMapping("/{versionId}/reject")
+    public ResponseEntity<ApiResponse<ReviewActionResponse>> rejectVersion(
+            @PathVariable String versionId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody ReviewActionRequest request
+    ) {
+        ReviewActionResponse response = scheduleVersionService.rejectVersion(
+                versionId, 
+                userDetails.getEmail(),
+                request
+        );
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+    
+    @PostMapping("/{versionId}/apply")
+    public ResponseEntity<ApiResponse<ScheduleApplyResponse>> applyVersionToSchedule(
+            @PathVariable String versionId
+    ) {
+        ScheduleApplyResponse response = scheduleVersionService.applyVersionToSchedule(versionId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
 }

--- a/src/main/java/com/portmate/domain/schedule/dto/ReviewActionRequest.java
+++ b/src/main/java/com/portmate/domain/schedule/dto/ReviewActionRequest.java
@@ -1,0 +1,14 @@
+package com.portmate.domain.schedule.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewActionRequest {
+    private String comment;
+}

--- a/src/main/java/com/portmate/domain/schedule/dto/ReviewActionResponse.java
+++ b/src/main/java/com/portmate/domain/schedule/dto/ReviewActionResponse.java
@@ -1,0 +1,22 @@
+package com.portmate.domain.schedule.dto;
+
+import com.portmate.domain.schedule.entity.ScheduleVersion;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewActionResponse {
+    private String versionId;
+    private String companyName;
+    private ScheduleVersion.VersionReviewerStatus reviewerStatus;
+    private ScheduleVersion.VersionStatus overallStatus;
+    private LocalDateTime actionTime;
+    private String message;
+}

--- a/src/main/java/com/portmate/domain/schedule/dto/ScheduleApplyResponse.java
+++ b/src/main/java/com/portmate/domain/schedule/dto/ScheduleApplyResponse.java
@@ -1,0 +1,21 @@
+package com.portmate.domain.schedule.dto;
+
+import com.portmate.domain.schedule.entity.ScheduleVersion;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleApplyResponse {
+    private String versionId;
+    private String originalScheduleId;
+    private ScheduleVersion.VersionStatus status;
+    private LocalDateTime appliedAt;
+    private String message;
+}

--- a/src/main/java/com/portmate/domain/schedule/dto/ScheduleVersionResponse.java
+++ b/src/main/java/com/portmate/domain/schedule/dto/ScheduleVersionResponse.java
@@ -2,6 +2,7 @@ package com.portmate.domain.schedule.dto;
 
 import com.portmate.domain.schedule.entity.ScheduleVersion;
 import com.portmate.domain.schedule.vo.ScheduleContent;
+import com.portmate.domain.schedule.vo.ScheduleVersionContent;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,5 +28,16 @@ public class ScheduleVersionResponse {
     private String createdByName;
     private String comment;
     private LocalDateTime createdAt;
-    private List<ScheduleContent> scheduleContents;
+    private List<ScheduleContent> scheduleContents; // 전체 스케줄 내용
+    private List<ScheduleVersionContent> changedContents; // 변경된 선박 정보만
+    private List<ReviewerInfo> reviewers;
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewerInfo {
+        private String companyName;
+        private ScheduleVersion.VersionReviewerStatus status;
+    }
 }

--- a/src/main/java/com/portmate/domain/schedule/entity/ScheduleVersion.java
+++ b/src/main/java/com/portmate/domain/schedule/entity/ScheduleVersion.java
@@ -1,6 +1,7 @@
 package com.portmate.domain.schedule.entity;
 
 import com.portmate.domain.schedule.vo.ScheduleContent;
+import com.portmate.domain.schedule.vo.ScheduleVersionContent;
 import com.portmate.global.entity.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,6 +12,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @Document(collection = "schedule_versions")
 @Getter
@@ -31,7 +33,9 @@ public class ScheduleVersion extends BaseEntity {
     
     private LocalDate endDt;
     
-    private List<ScheduleContent> scheduleContents; // 변경된 선박 배치
+    private List<ScheduleContent> scheduleContents; // 전체 스케줄 내용 (변경 후)
+    
+    private List<ScheduleVersionContent> changedContents; // 변경된 선박들의 변경 정보
     
     private VersionStatus status;
     
@@ -40,23 +44,31 @@ public class ScheduleVersion extends BaseEntity {
     private String createdByName; // 수정자 이름
     
     private String comment; // 수정 사유
-    
-    public enum VersionStatus {
+
+    private Map<String, VersionReviewerStatus> reviewers;
+
+    public enum VersionReviewerStatus {
         PENDING,   // 승인 대기
         APPROVED,  // 승인됨
         REJECTED,  // 거부됨
+    }
+    
+    public enum VersionStatus {
+        PENDING,   // 승인 대기
+        APPROVED,  // 모든 리뷰어 승인 완료
+        REJECTED,  // 거부됨
+        APPLIED,   // 스케줄에 반영 완료
         CANCELLED  // 취소됨
     }
     
-    public void approve() {
-        this.status = VersionStatus.APPROVED;
+    // 상태 업데이트를 위한 단순한 setter 메서드들
+    public void updateStatus(VersionStatus newStatus) {
+        this.status = newStatus;
     }
     
-    public void reject() {
-        this.status = VersionStatus.REJECTED;
-    }
-    
-    public void cancel() {
-        this.status = VersionStatus.CANCELLED;
+    public void updateReviewerStatus(String companyName, VersionReviewerStatus reviewerStatus) {
+        if (reviewers != null && reviewers.containsKey(companyName)) {
+            reviewers.put(companyName, reviewerStatus);
+        }
     }
 }

--- a/src/main/java/com/portmate/domain/schedule/service/ScheduleVersionService.java
+++ b/src/main/java/com/portmate/domain/schedule/service/ScheduleVersionService.java
@@ -6,10 +6,13 @@ import com.portmate.domain.schedule.entity.ScheduleVersion;
 import com.portmate.domain.schedule.repository.ScheduleRepository;
 import com.portmate.domain.schedule.repository.ScheduleVersionRepository;
 import com.portmate.domain.schedule.vo.ScheduleContent;
+import com.portmate.domain.schedule.vo.ScheduleVersionContent;
 import com.portmate.domain.schedule.util.DateParser;
 import com.portmate.domain.pier.entity.Pier;
 import com.portmate.domain.pier.entity.ShipType;
 import com.portmate.domain.pier.repository.PierRepository;
+import com.portmate.domain.user.entity.User;
+import com.portmate.domain.user.repository.UserRepository;
 
 import com.portmate.global.response.exception.GlobalException;
 import com.portmate.global.response.status.ErrorStatus;
@@ -23,10 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,6 +36,7 @@ public class ScheduleVersionService {
     private final ScheduleVersionRepository versionRepository;
     private final ScheduleRepository scheduleRepository;
     private final PierRepository pierRepository;
+    private final UserRepository userRepository;
     
 
     public ScheduleValidateResponse validateScheduleModification(ScheduleValidateRequest request) {
@@ -132,6 +133,12 @@ public class ScheduleVersionService {
                 .orElseThrow(() -> new GlobalException(ErrorStatus.SCHEDULE_NOT_FOUND));
 
         List<ScheduleContent> updatedContents = createUpdatedContents(schedule, request.getPlacements());
+        
+        // 변경된 선박들의 변경 정보 계산
+        List<ScheduleVersionContent> changedContents = calculateChanges(schedule.getScheduleContents(), updatedContents);
+        
+        // 리뷰어 초기화 - 변경된 선박들의 대리점만 리뷰어로 설정
+        Map<String, ScheduleVersion.VersionReviewerStatus> reviewers = initializeReviewersFromChangedContents(changedContents);
 
         ScheduleVersion version = ScheduleVersion.builder()
                 .versionId(UUID.randomUUID().toString())
@@ -141,10 +148,12 @@ public class ScheduleVersionService {
                 .startDt(schedule.getStartDt())
                 .endDt(schedule.getEndDt())
                 .scheduleContents(updatedContents)
+                .changedContents(changedContents) // 변경된 선박 정보
                 .status(ScheduleVersion.VersionStatus.PENDING) // 승인 대기
                 .createdBy(userId)
                 .createdByName(userName)
                 .comment(request.getComment())
+                .reviewers(reviewers) // 리뷰어 설정
                 .build();
         
         ScheduleVersion saved = versionRepository.save(version);
@@ -161,17 +170,7 @@ public class ScheduleVersionService {
         ScheduleVersion version = versionRepository.findById(versionId)
                 .orElseThrow(() -> new GlobalException(ErrorStatus.SCHEDULE_NOT_FOUND));
         
-        return ScheduleVersionResponse.builder()
-                .versionId(version.getVersionId())
-                .originalScheduleId(version.getOriginalScheduleId())
-                .pier(version.getPier())
-                .berth(version.getBerth())
-                .startDt(version.getStartDt())
-                .endDt(version.getEndDt())
-                .status(version.getStatus())
-                .createdAt(version.getCreatedAt())
-                .scheduleContents(version.getScheduleContents())
-                .build();
+        return toResponse(version);
     }
 
     public PageResponse<List<ScheduleVersionResponse>> getAllVersions(int page, int size) {
@@ -192,6 +191,17 @@ public class ScheduleVersionService {
     }
 
     private ScheduleVersionResponse toResponse(ScheduleVersion version) {
+        List<ScheduleVersionResponse.ReviewerInfo> reviewerInfos = new ArrayList<>();
+        
+        if (version.getReviewers() != null) {
+            reviewerInfos = version.getReviewers().entrySet().stream()
+                    .map(entry -> ScheduleVersionResponse.ReviewerInfo.builder()
+                            .companyName(entry.getKey())
+                            .status(entry.getValue())
+                            .build())
+                    .collect(Collectors.toList());
+        }
+        
         return ScheduleVersionResponse.builder()
                 .versionId(version.getVersionId())
                 .originalScheduleId(version.getOriginalScheduleId())
@@ -205,6 +215,8 @@ public class ScheduleVersionService {
                 .comment(version.getComment())
                 .createdAt(version.getCreatedAt())
                 .scheduleContents(version.getScheduleContents())
+                .changedContents(version.getChangedContents()) // 변경된 선박 정보 포함
+                .reviewers(reviewerInfos)
                 .build();
     }
     
@@ -234,6 +246,7 @@ public class ScheduleVersionService {
                         .tonnage(originalContent.getTonnage())
                         .flag(originalContent.getFlag())
                         .remark(originalContent.getRemark())
+                        .agent(originalContent.getAgent())
                         .pier(placement.getPier())
                         .berth(placement.getBerth())
                         .build();
@@ -286,5 +299,229 @@ public class ScheduleVersionService {
                 .map(Pier::getId)
                 .findFirst()
                 .orElse(null);
+    }
+
+    private Map<String, ScheduleVersion.VersionReviewerStatus> initializeReviewersFromChangedContents(List<ScheduleVersionContent> changedContents) {
+        Map<String, ScheduleVersion.VersionReviewerStatus> reviewers = new HashMap<>();
+
+        Set<String> agentCompanies = new HashSet<>();
+        
+        for (ScheduleVersionContent content : changedContents) {
+            String originalAgent = content.getOriginalContent().getAgent();
+            if (originalAgent != null && !originalAgent.trim().isEmpty()) {
+                agentCompanies.add(originalAgent);
+            }
+
+            String modifiedAgent = content.getModifiedContent().getAgent();
+            if (modifiedAgent != null && !modifiedAgent.trim().isEmpty()) {
+                agentCompanies.add(modifiedAgent);
+            }
+        }
+
+        for (String agent : agentCompanies) {
+            reviewers.put(agent, ScheduleVersion.VersionReviewerStatus.PENDING);
+        }
+        
+        return reviewers;
+    }
+
+    private List<ScheduleVersionContent> calculateChanges(List<ScheduleContent> originalContents, 
+                                                          List<ScheduleContent> updatedContents) {
+        List<ScheduleVersionContent> changes = new ArrayList<>();
+
+        Map<String, ScheduleContent> originalMap = originalContents.stream()
+                .collect(Collectors.toMap(ScheduleContent::getVesselName, content -> content));
+
+        Map<String, ScheduleContent> updatedMap = updatedContents.stream()
+                .collect(Collectors.toMap(ScheduleContent::getVesselName, content -> content));
+
+        for (String vesselName : originalMap.keySet()) {
+            ScheduleContent original = originalMap.get(vesselName);
+            ScheduleContent updated = updatedMap.get(vesselName);
+            
+            if (updated != null && hasChanges(original, updated)) {
+                ScheduleVersionContent change = ScheduleVersionContent.builder()
+                        .vesselName(vesselName)
+                        .changeType(determineChangeType(original, updated))
+                        .originalContent(original)
+                        .modifiedContent(updated)
+                        .build();
+                
+                changes.add(change);
+            }
+        }
+        
+        return changes;
+    }
+    
+    private boolean hasChanges(ScheduleContent original, ScheduleContent updated) {
+        return !Objects.equals(original.getEta(), updated.getEta()) ||
+               !Objects.equals(original.getEtd(), updated.getEtd()) ||
+               !Objects.equals(original.getPier(), updated.getPier()) ||
+               !Objects.equals(original.getBerth(), updated.getBerth());
+    }
+    
+    private ScheduleVersionContent.ChangeType determineChangeType(ScheduleContent original, ScheduleContent updated) {
+        int changeCount = 0;
+        ScheduleVersionContent.ChangeType lastChangeType = null;
+        
+        if (!Objects.equals(original.getEta(), updated.getEta())) {
+            changeCount++;
+            lastChangeType = ScheduleVersionContent.ChangeType.ETA_CHANGED;
+        }
+        
+        if (!Objects.equals(original.getEtd(), updated.getEtd())) {
+            changeCount++;
+            lastChangeType = ScheduleVersionContent.ChangeType.ETD_CHANGED;
+        }
+        
+        if (!Objects.equals(original.getPier(), updated.getPier())) {
+            changeCount++;
+            lastChangeType = ScheduleVersionContent.ChangeType.PIER_CHANGED;
+        }
+        
+        if (!Objects.equals(original.getBerth(), updated.getBerth())) {
+            changeCount++;
+            lastChangeType = ScheduleVersionContent.ChangeType.BERTH_CHANGED;
+        }
+        
+        return changeCount > 1 ? ScheduleVersionContent.ChangeType.MULTIPLE_CHANGED : lastChangeType;
+    }
+ 
+    @Transactional
+    public ReviewActionResponse approveVersion(String versionId, String email, ReviewActionRequest request) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new GlobalException(ErrorStatus.USER_NOT_FOUND));
+
+        ScheduleVersion version = versionRepository.findById(versionId)
+                .orElseThrow(() -> new GlobalException(ErrorStatus.SCHEDULE_NOT_FOUND));
+
+        if (!isReviewerAuthorized(version, user.getCompany())) {
+            throw new GlobalException(ErrorStatus.UNAUTHORIZED_REVIEW);
+        }
+
+        if (isAlreadyProcessed(version)) {
+            throw new GlobalException(ErrorStatus.VERSION_ALREADY_PROCESSED);
+        }
+        
+        // 승인 처리
+        approveByReviewer(version, user.getCompany());
+        ScheduleVersion saved = versionRepository.save(version);
+        
+        String message = saved.getStatus() == ScheduleVersion.VersionStatus.APPROVED ?
+                "모든 리뷰어가 승인하여 버전이 최종 승인되었습니다." :
+                "승인이 완료되었습니다.";
+        
+        return ReviewActionResponse.builder()
+                .versionId(versionId)
+                .companyName(user.getCompany())
+                .reviewerStatus(ScheduleVersion.VersionReviewerStatus.APPROVED)
+                .overallStatus(saved.getStatus())
+                .actionTime(LocalDateTime.now())
+                .message(message)
+                .build();
+    }
+    
+    @Transactional
+    public ReviewActionResponse rejectVersion(String versionId, String email, ReviewActionRequest request) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new GlobalException(ErrorStatus.USER_NOT_FOUND));
+
+        ScheduleVersion version = versionRepository.findById(versionId)
+                .orElseThrow(() -> new GlobalException(ErrorStatus.SCHEDULE_NOT_FOUND));
+
+        if (!isReviewerAuthorized(version, user.getCompany())) {
+            throw new GlobalException(ErrorStatus.UNAUTHORIZED_REVIEW);
+        }
+
+        if (isAlreadyProcessed(version)) {
+            throw new GlobalException(ErrorStatus.VERSION_ALREADY_PROCESSED);
+        }
+
+        rejectByReviewer(version, user.getCompany());
+        ScheduleVersion saved = versionRepository.save(version);
+        
+        return ReviewActionResponse.builder()
+                .versionId(versionId)
+                .companyName(user.getCompany())
+                .reviewerStatus(ScheduleVersion.VersionReviewerStatus.REJECTED)
+                .overallStatus(saved.getStatus())
+                .actionTime(LocalDateTime.now())
+                .message("버전이 거부되었습니다.")
+                .build();
+    }
+    
+    @Transactional
+    public ScheduleApplyResponse applyVersionToSchedule(String versionId) {
+        ScheduleVersion version = versionRepository.findById(versionId)
+                .orElseThrow(() -> new GlobalException(ErrorStatus.SCHEDULE_NOT_FOUND));
+
+        if (version.getStatus() != ScheduleVersion.VersionStatus.APPROVED) {
+            throw new GlobalException(ErrorStatus.VERSION_NOT_APPROVED);
+        }
+
+        Schedule originalSchedule = scheduleRepository.findById(version.getOriginalScheduleId())
+                .orElseThrow(() -> new GlobalException(ErrorStatus.SCHEDULE_NOT_FOUND));
+
+        Schedule updatedSchedule = Schedule.builder()
+                .scheduleId(originalSchedule.getScheduleId())
+                .pier(originalSchedule.getPier())
+                .berth(originalSchedule.getBerth())
+                .startDt(originalSchedule.getStartDt())
+                .endDt(originalSchedule.getEndDt())
+                .scheduleContents(version.getScheduleContents())
+                .build();
+
+        scheduleRepository.save(updatedSchedule);
+
+        applyVersion(version);
+        ScheduleVersion savedVersion = versionRepository.save(version);
+        
+        return ScheduleApplyResponse.builder()
+                .versionId(versionId)
+                .originalScheduleId(version.getOriginalScheduleId())
+                .status(savedVersion.getStatus())
+                .appliedAt(LocalDateTime.now())
+                .message("스케줄이 성공적으로 적용되었습니다.")
+                .build();
+    }
+
+    private boolean isReviewerAuthorized(ScheduleVersion version, String companyName) {
+        return version.getReviewers() != null && version.getReviewers().containsKey(companyName);
+    }
+    
+    private boolean isAlreadyProcessed(ScheduleVersion version) {
+        return version.getStatus() == ScheduleVersion.VersionStatus.APPROVED || 
+               version.getStatus() == ScheduleVersion.VersionStatus.REJECTED || 
+               version.getStatus() == ScheduleVersion.VersionStatus.APPLIED || 
+               version.getStatus() == ScheduleVersion.VersionStatus.CANCELLED;
+    }
+    
+    private void approveByReviewer(ScheduleVersion version, String companyName) {
+        version.updateReviewerStatus(companyName, ScheduleVersion.VersionReviewerStatus.APPROVED);
+
+        if (checkAllReviewersApproved(version)) {
+            version.updateStatus(ScheduleVersion.VersionStatus.APPROVED);
+        }
+    }
+    
+    private void rejectByReviewer(ScheduleVersion version, String companyName) {
+        version.updateReviewerStatus(companyName, ScheduleVersion.VersionReviewerStatus.REJECTED);
+        version.updateStatus(ScheduleVersion.VersionStatus.REJECTED);
+    }
+    
+    private void applyVersion(ScheduleVersion version) {
+        if (version.getStatus() == ScheduleVersion.VersionStatus.APPROVED) {
+            version.updateStatus(ScheduleVersion.VersionStatus.APPLIED);
+        }
+    }
+    
+    private boolean checkAllReviewersApproved(ScheduleVersion version) {
+        if (version.getReviewers() == null || version.getReviewers().isEmpty()) {
+            return false;
+        }
+        
+        return version.getReviewers().values().stream()
+                .allMatch(status -> status == ScheduleVersion.VersionReviewerStatus.APPROVED);
     }
 }

--- a/src/main/java/com/portmate/domain/schedule/vo/ScheduleContent.java
+++ b/src/main/java/com/portmate/domain/schedule/vo/ScheduleContent.java
@@ -51,8 +51,12 @@ public class ScheduleContent {
     // 비고 (Remark)
     private String remark;
 
+    private String agent;
+
     private String pier;
     private String berth;
+
+
 
     public static ScheduleContent from(CSVRecord record) {
         return ScheduleContent.builder()
@@ -69,6 +73,7 @@ public class ScheduleContent {
                 .tonnage(record.get("톤수 (Tonnage)"))
                 .flag(record.get("국적 (Flag)"))
                 .remark(record.get("비고 (Remark)"))
+                .agent(record.get("대리점"))
                 .build();
     }
 }

--- a/src/main/java/com/portmate/domain/schedule/vo/ScheduleVersionContent.java
+++ b/src/main/java/com/portmate/domain/schedule/vo/ScheduleVersionContent.java
@@ -1,0 +1,60 @@
+package com.portmate.domain.schedule.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleVersionContent {
+    
+    private String vesselName; // 선박명
+    private ChangeType changeType; // 변경 타입
+    private ScheduleContent originalContent; // 변경 전 정보
+    private ScheduleContent modifiedContent; // 변경 후 정보
+    
+    public enum ChangeType {
+        ETA_CHANGED,    // ETA 변경
+        ETD_CHANGED,    // ETD 변경
+        PIER_CHANGED,   // 부두 변경
+        BERTH_CHANGED,  // 선석 변경
+        MULTIPLE_CHANGED // 여러 항목 변경
+    }
+
+    public String getChangeDescription() {
+        if (originalContent == null || modifiedContent == null) {
+            return "정보 없음";
+        }
+        
+        StringBuilder description = new StringBuilder();
+
+        if (!originalContent.getEta().equals(modifiedContent.getEta())) {
+            description.append(String.format("ETA: %s → %s, ", 
+                originalContent.getEta(), modifiedContent.getEta()));
+        }
+
+        if (!originalContent.getEtd().equals(modifiedContent.getEtd())) {
+            description.append(String.format("ETD: %s → %s, ", 
+                originalContent.getEtd(), modifiedContent.getEtd()));
+        }
+
+        if (!originalContent.getPier().equals(modifiedContent.getPier())) {
+            description.append(String.format("부두: %s → %s, ", 
+                originalContent.getPier(), modifiedContent.getPier()));
+        }
+
+        if (!originalContent.getBerth().equals(modifiedContent.getBerth())) {
+            description.append(String.format("선석: %s → %s, ", 
+                originalContent.getBerth(), modifiedContent.getBerth()));
+        }
+
+        if (description.length() > 0) {
+            description.setLength(description.length() - 2);
+        }
+        
+        return description.toString();
+    }
+}

--- a/src/main/java/com/portmate/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/portmate/global/response/status/ErrorStatus.java
@@ -36,7 +36,12 @@ public enum ErrorStatus implements BaseStatusCode {
     // Berth Change
     INVALID_BERTH_PLACEMENT(HttpStatus.BAD_REQUEST, "BERTH_CHANGE_001", "유효하지 않은 선석 배치입니다."),
     CHANGE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "BERTH_CHANGE_002", "변경 요청을 찾을 수 없습니다."),
-    CANNOT_CANCEL_REQUEST(HttpStatus.BAD_REQUEST, "BERTH_CHANGE_003", "취소할 수 없는 상태의 요청입니다.");
+    CANNOT_CANCEL_REQUEST(HttpStatus.BAD_REQUEST, "BERTH_CHANGE_003", "취소할 수 없는 상태의 요청입니다."),
+
+    // Schedule Version Review
+    UNAUTHORIZED_REVIEW(HttpStatus.FORBIDDEN, "VERSION_REVIEW_001", "해당 버전을 승인/거부할 권한이 없습니다."),
+    VERSION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "VERSION_REVIEW_002", "이미 처리된 버전입니다."),
+    VERSION_NOT_APPROVED(HttpStatus.BAD_REQUEST, "VERSION_REVIEW_003", "승인되지 않은 버전은 스케줄에 적용할 수 없습니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- schedule 컬렉션에 agent 필드 추가(엑셀 대리점 컬럼 추가 및 agent는 user 컬렉션의 company 필드와 연결됨)
- 스케줄 변경 요청 시 리뷰어의 승인을 받아야함 -> 모든 리뷰어가 승인하면 스케줄 최종 반영
- 스케줄이 변동된 선박에 한정해서 리뷰 요청이 가게 됨

승인 전 pending
<img width="825" height="670" alt="스크린샷 2025-10-12 23 10 26" src="https://github.com/user-attachments/assets/cc689028-a7cf-44ac-969e-154bc0cc5017" />




승인 후 approved
<img width="355" height="184" alt="스크린샷 2025-10-12 23 10 54" src="https://github.com/user-attachments/assets/fb3be2f8-389a-40e0-99c2-d6fbc8573f55" />


최종 반영 후
<img width="524" height="243" alt="image" src="https://github.com/user-attachments/assets/2cccf7f8-701b-4150-99b1-020d1adbd457" />
이후 schedule 업데이트 됨
---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
-  스케줄 변경 관련 필드 추가
-  엑셀 파싱 시 대리점 컬럼 추가 
- 스케줄 변경 승인, 거절, 조회, 스케줄 최종 반영 로직 구현


---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #32 

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->
